### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ __pycache__
 pytest*.xml
 .mypy_cache
 .*cache
+
+# python3 -m venv venv
+# source venv/bin/activate
+# pip3 install -r tests/requirements.txt
+venv
+venv/*
+.venv
+.venv/*


### PR DESCRIPTION
Use venv among best practices for running pytest
venv can be sourced from vscode too and Python test explorer.