### PR TITLE
github-action/build.yml deploys openapi.json on GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,8 @@ jobs:
 
   rmdev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
       with:
@@ -114,6 +116,24 @@ jobs:
         alias dcdev="docker compose -p rmdev -f docker-compose-local.yml -f docker-compose-dev.yml"
         dcdev up --wait || ( dcdev logs && exit 1 )
       continue-on-error: true
+    - name: generate openapi.json
+      id: generate_openapijson
+      run: curl http://localhost:8000/api/openapi.json -o openapi.json
+    - name: generate swagger ui
+      uses: Legion2/swagger-ui-action@v1
+      with:
+        output: swagger-ui
+        version: 3.1.0
+        spec-file: ./openapi.json
+    - name: list swagger-ui dir
+      run: |
+        ls ./swagger-ui/
+        cat ./swagger-ui/swagger-config.json
+    - name: deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: swagger-ui
     - name: run pytest
       id: run_pytest
       uses: pavelzw/pytest-action@v2


### PR DESCRIPTION
Up to date openapi.json available at: https://pvarki.github.io/docker-rasenmaeher-integration/openapi.json

Changes in this PR "publish" swagger/openapi.json into gh-pages branch, which is in turn build by a github-bot in the actions servicing the json in the above mentioned url-endpoint.