### PR TITLE
mtls cert bundle sequence diagram

### DIFF
--- a/mermaid/admin-creates-invite-code-QR.mermaid
+++ b/mermaid/admin-creates-invite-code-QR.mermaid
@@ -1,0 +1,6 @@
+sequenceDiagram
+    hallintakännykkä->>API: /enrollment/list
+    API->>hallintakännykkä: <users_list>
+    hallintakännykkä->>API: /enrollment/invitecode/create
+    API->>hallintakännykkä: <invite_code>
+    hallintakännykkä->>hallintakännykkä: generoi QR {<invite_code>}

--- a/mermaid/admin-shows-QR-and-user-gets-mtls-cert-bundle.mermaid
+++ b/mermaid/admin-shows-QR-and-user-gets-mtls-cert-bundle.mermaid
@@ -1,12 +1,8 @@
 sequenceDiagram
-    hallintakännykkä->>API: /enrollment/list
-    API->>hallintakännykkä: <users_list>
-    hallintakännykkä->>API: /enrollment/invitecode/create
-    API->>hallintakännykkä: <invite_code>
-    hallintakännykkä->>toinen kännykkä: anna koodi tai näytä QR
-    toinen kännykkä->>hallintakännykkä: /enrollment/invitecode?code=<invite_code>
+    hallintakännykkä->>toinen kännykkä: anna <invite_code> tai näytä QR
+    toinen kännykkä->>API: /enrollment/invitecode?code=<invite_code>
     API->>toinen kännykkä: <invite_code active: true/false>
-    toinen kännykkä->>toinen kännykkä: onko koodi ok?
+    toinen kännykkä->>toinen kännykkä: onko <invite_code> ok?
     toinen kännykkä->>API: /enrollment/invitecode/enroll: {<invite_code>, <work_id>}
     API->>toinen kännykkä: <user_jwt>
     toinen kännykkä->>API: /enrollment/have-I-been-accepted

--- a/mermaid/mtls-cert-bundle.mermaid
+++ b/mermaid/mtls-cert-bundle.mermaid
@@ -1,0 +1,26 @@
+sequenceDiagram
+    hallintakännykkä->>API: /enrollment/list
+    API->>hallintakännykkä: <users_list>
+    hallintakännykkä->>API: /enrollment/invitecode/create
+    API->>hallintakännykkä: <invite_code>
+    hallintakännykkä->>toinen kännykkä: anna koodi tai näytä QR
+    toinen kännykkä->>hallintakännykkä: /enrollment/invitecode?code=<invite_code>
+    API->>toinen kännykkä: <invite_code active: true/false>
+    toinen kännykkä->>toinen kännykkä: onko koodi ok?
+    toinen kännykkä->>API: /enrollment/invitecode/enroll: {<invite_code>, <work_id>}
+    API->>toinen kännykkä: <user_jwt>
+    toinen kännykkä->>API: /enrollment/have-I-been-accepted
+    API->>toinen kännykkä: <false>
+    toinen kännykkä->>toinen kännykkä: onko minut hyväksytty?
+    hallintakännykkä->>API: /enrollment/list
+    API->>hallintakännykkä: <users_list>
+    hallintakännykkä->>hallintakännykkä: toinen kännykkä näkyy
+    hallintakännykkä->>API: /enrollment/accept: {<work_id>}
+    API->>hallintakännykkä: <OK>
+    toinen kännykkä->>API: /enrollment/have-I-been-accepted
+    API->>toinen kännykkä: <true>
+    toinen kännykkä->>toinen kännykkä: minut on hyväksytty
+    toinen kännykkä->>toinen kännykkä: hae MTLS certifikaatti.zip
+    toinen kännykkä->>API: /enduserpfx/callsign
+    API->>toinen kännykkä: <MTLS cert bundle>
+    toinen kännykkä->>toinen kännykkä: onko MTLS cerfikaatti.zip ok?


### PR DESCRIPTION
We will iterate sequences whenever we learn new things in the course of testing the scenarios. Once scenario testing has completed we should have sequences ready. Until then let's keep this PR as draft.

-------------------------------

Version 24.9: based on quick comments from @karppo 

(Still missing sequence where firstuser elevates itself to admin)

**2. Admin creates invite_code / QR**
![image](https://github.com/pvarki/docker-rasenmaeher-integration/assets/126289237/213abcc0-156e-4483-b183-e6c39825d1fd)

**3. Admin shows invite_code / QR and user gets mtls cert bundle**

![image](https://github.com/pvarki/docker-rasenmaeher-integration/assets/126289237/c93277d1-8c9e-48d6-9d9f-232991676d94)

-------------------------------

**First version 23.9 - now obsolete:**

![image](https://github.com/pvarki/docker-rasenmaeher-integration/assets/126289237/70191b14-0efd-47d4-9e3c-e4a48b6580d4)
