### PR TITLE
[Feature] Elasticagent + conditionally Elasticsearch+Kibana in deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -445,6 +445,23 @@ services:
       start_period: 5s
     restart: unless-stopped
 
+  elastic-agent:
+    image: docker.elastic.co/beats/elastic-agent:8.10.1
+    container_name: elastic-agent
+    user: root
+    environment:
+      ELASTIC_AGENT_ENROLLMENT_TOKEN: ${ELASTIC_AGENT_ENROLLMENT_TOKEN}
+      ELASTIC_AGENT_FLEET_URL: ${ELASTIC_AGENT_FLEET_URL}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /sys/fs/cgroup:/hostfs/sys/fs/cgroup
+      - /proc:/hostfs/proc
+      - /:/hostfs
+      - ./elastic-agent-config/elastic-agent.yml:/usr/share/elastic-agent/elastic-agent.yml
+    networks:
+      - loggingnet
+    restart: unless-stopped
+
   kwinit:  # Mostly to make sure it's built
     image: pvarki/kw_product_init:1.0.0-d${RELEASE_TAG:-1.5.1}${DOCKER_TAG_EXTRA:-}
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -466,7 +466,6 @@ services:
   # BEGIN profile: kibana  #
   ##########################
 
-  # profile: kibana - deploy conditionally if profile: kibana is used
     elasticsearch:
       image: docker.elastic.co/elasticsearch/elasticsearch:8.10.1
       container_name: elasticsearch
@@ -491,7 +490,6 @@ services:
       profiles:
         - kibana
 
-    # profile: kibana - deploy conditionally if profile: kibana is used
     kibana:
       image: docker.elastic.co/kibana/kibana:8.10.1
       container_name: kibana
@@ -509,7 +507,6 @@ services:
       profiles:
         - kibana
 
-  # profile: kibana - deploy conditionally if profile: kibana is used
   kibananginx:
     <<: *nginxbuildinfo
     volumes:
@@ -811,6 +808,7 @@ networks:
   dbnet:
   intranet:
   taknet:
+  loggingnet:
 
 volumes:
   kraftwerk_data:
@@ -829,3 +827,4 @@ volumes:
   takrmapi_data:
   rmui_files:
   nginx_templates:
+  es_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -462,6 +462,99 @@ services:
       - loggingnet
     restart: unless-stopped
 
+  ##########################
+  # BEGIN profile: kibana  #
+  ##########################
+
+  # profile: kibana - deploy conditionally if profile: kibana is used
+    elasticsearch:
+      image: docker.elastic.co/elasticsearch/elasticsearch:8.10.1
+      container_name: elasticsearch
+      environment:
+        - node.name=elasticsearch
+        - discovery.type=single-node
+        - network.host=0.0.0.0
+        - bootstrap.memory_lock=true
+        - xpack.security.enabled=false
+        - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+      volumes:
+        - es_data:/usr/share/elasticsearch/data
+      networks:
+        - loggingnet
+      ports:
+        - "9200:9200"
+      restart: unless-stopped
+      profiles:
+        - kibana
+
+    # profile: kibana - deploy conditionally if profile: kibana is used
+    kibana:
+      image: docker.elastic.co/kibana/kibana:8.10.1
+      container_name: kibana
+      environment:
+        - SERVER_NAME=kibana
+        - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+        - XPACK_SECURITY_ENABLED=false
+      depends_on:
+        - elasticsearch
+      networks:
+        - loggingnet
+      expose:
+        - "5601"
+      restart: unless-stopped
+      profiles:
+        - kibana
+
+  # profile: kibana - deploy conditionally if profile: kibana is used
+  kibananginx:
+    <<: *nginxbuildinfo
+    volumes:
+      - nginx_templates:/nginx_templates
+      - ca_public:/ca_public
+      - le_certs:/le_certs
+    environment:
+      NGINX_HOST: "kibana.${SERVER_DOMAIN}"
+      NGINX_HTTP_PORT: "80"
+      NGINX_HTTPS_PORT: "5601"
+      NGINX_UPSTREAM: "kibana"
+      NGINX_UPSTREAM_PORT: "5601"
+      NGINX_CERT_NAME: "kibana"
+      CFSSL_OCSP_BIND_PORT: *oscpport
+      NGINX_OCSP_UPSTREAM: *ocsphost
+      DNS_RESOLVER_IP: *dnsresolver
+      NGINX_TEMPLATE_DIR: "templates_kibana"
+    networks:
+      - loggingnet
+      - ocspnet
+    ports:
+      - "5601:5601"
+    depends_on:
+      kibana:
+        condition: service_started
+      nginx_templates:
+        condition: service_completed_successfully
+      ocsp:
+        condition: service_healthy
+      cfssl:
+        condition: service_healthy
+    healthcheck:
+      test: 'curl -s localhost:5666/healthcheck || exit 1'
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    profiles:
+      - kibana
+
+  ##########################
+  # END profile: kibana  #
+  ##########################
+
   kwinit:  # Mostly to make sure it's built
     image: pvarki/kw_product_init:1.0.0-d${RELEASE_TAG:-1.5.1}${DOCKER_TAG_EXTRA:-}
     build:

--- a/elastic-agent-config/elastic-agent.yml
+++ b/elastic-agent-config/elastic-agent.yml
@@ -1,0 +1,22 @@
+{% if ELASTIC_AGENT_ENROLLMENT_TOKEN and ELASTIC_AGENT_FLEET_URL %}
+fleet:
+  enrollment_token: ${ELASTIC_AGENT_ENROLLMENT_TOKEN}
+  hosts:
+    - ${ELASTIC_AGENT_FLEET_URL}
+{% else %}
+outputs:
+  default:
+    type: elasticsearch
+    hosts:
+      - http://elasticsearch:9200
+
+inputs:
+  - id: docker-logs
+    type: logfile
+    streams:
+      - paths:
+          - /var/lib/docker/containers/*/*.log
+        parsers:
+          - ndjson:
+              message_key: log
+{% endif %}

--- a/nginx/templates_kibana/default.conf.template
+++ b/nginx/templates_kibana/default.conf.template
@@ -1,0 +1,34 @@
+ssl_certificate /le_certs/${NGINX_CERT_NAME}/fullchain.pem;
+ssl_certificate_key /le_certs/${NGINX_CERT_NAME}/privkey.pem;
+
+include /etc/nginx/includes/le_common_settings.conf;
+
+server {
+    server_name ${NGINX_HOST};
+
+    # HTTPS configuration
+    listen ${NGINX_HTTPS_PORT} ssl;
+
+    ssl_client_certificate /ca_public/ca_chain.pem;
+    ssl_verify_client      on;
+    ssl_ocsp leaf;
+    ssl_ocsp_responder http://${NGINX_OCSP_UPSTREAM}:${CFSSL_OCSP_BIND_PORT};
+    resolver ${DNS_RESOLVER_IP} ipv6=off;
+    #ssl_crl /ca_public/crl.pem;
+    ssl_verify_depth 3;
+
+    location / {
+        if ($ssl_client_verify != SUCCESS) {
+            return 401;
+        }
+        proxy_pass  http://${NGINX_UPSTREAM}:${NGINX_UPSTREAM_PORT};
+        proxy_redirect                      off;
+        proxy_set_header  Host              $http_host;
+        proxy_set_header  X-Real-IP         $remote_addr;
+        proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto $scheme;
+        proxy_read_timeout                  900;
+        proxy_set_header  X-ClientCert-DN   $ssl_client_s_dn;
+        proxy_set_header  X-ClientCert-Serial   $ssl_client_serial;
+    }
+}


### PR DESCRIPTION
# What
Add in configurations for elasticagent:
- Conditionally, with docker compose profile: kibana, run Elasticsearch and Kibana in the compose, so that you can tinker with logging in eg. a dev deployment.
- If local setup is not used, then with injected token and url, ship logs to your preferred destination.

# How
elastic-agent-config/elastic-agent.yml
```
{% if ELASTIC_AGENT_ENROLLMENT_TOKEN and ELASTIC_AGENT_FLEET_URL %}
fleet:
  enrollment_token: ${ELASTIC_AGENT_ENROLLMENT_TOKEN}
  hosts:
    - ${ELASTIC_AGENT_FLEET_URL}
{% else %}
outputs:
  default:
    type: elasticsearch
    hosts:
      - http://elasticsearch:9200

inputs:
  - id: docker-logs
    type: logfile
    streams:
      - paths:
          - /var/lib/docker/containers/*/*.log
        parsers:
          - ndjson:
              message_key: log
{% endif %}
```
Then in compose, set elasticagent as a service and elasticsearch, kibana, kibananginx as conditional services. Access kibana at kibana.fqdn with your mTLS cert.

# Why
Logging is good for you
Tryout
