### PR TITLE
updated ui pointer

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 commit = False
 tag = False
 


### PR DESCRIPTION
# Copied from the ui update:

# What Does This PR Do
- Add in KeyCloakUI access button to /app/admin/user-management. This is due as our version tag 1.6.0, we got Keycloak integrated.
- At footer, check & show users deployment version, rather than RMAPI version
- Fix few self-inflicted bugs with loginpage after the last merger
- Dependency upgrade

## Keycloak button
Add Keycloak button behind an unfoldable card at ManageUsersView, pics below.
![addkc](https://github.com/user-attachments/assets/e89746da-5257-42fc-b0a5-9b939db12843)
![Näyttökuva 2025-02-04 002024](https://github.com/user-attachments/assets/2fb171b4-7578-49dc-9b6b-619d54046598)
- This is really just useful for expert users at the moment
- And for them to tell that Here It Is instead of having to guess where it is

## Version
Earlier the footer used the rmapi api/v1/healthcheck call and showed the version value there to users. This confused users a bit. So we now show them the deployment version according to whatever is the RELEASE_TAG (eg. 1.6.0) at present deployment. 
- for this, we need to inject RELEASE_TAG env var to rmui's use at docker-compose.yml & for rmuidev at docker-compose-dev.yml. 
- I'll be adding those in an integration repo pointer update PR once we're there

## Bugfixes
These regard to the lastly merged QoL feature of automatically go to Callisign view, if we come with login code link (
- LoginView now awaits user manual input to the Formik form, instead of instantly polling whether a correct code was typed
- EnrollmentView does not flicker in some cases when an admin approves an user's enrollment, and the user is redirected to CreateMtlsView

## Upgrades
- Upgrade deps
- Vite seems to require defining allowed hosts, so define them (per SERVER_DOMAIN var from env, and 0.0.0.0 from docker network)