### PR TITLE
Update openapijson.yml to include github token for swagger

### DIFF
--- a/.github/workflows/openapijson.yml
+++ b/.github/workflows/openapijson.yml
@@ -30,6 +30,7 @@ jobs:
           output: swagger-ui
           spec-file: openapi.json
           version: ^5.0.0
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to gh-pages
         if: ${{ !env.ACT }}
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
the swagger instance itself didnt have a github token and it was complaint in the logs. Should fix to half off #127 