### PR TITLE
openapijson_to_gh-pages and sphinx_docs_to_gh-pages use deprecated actions fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
           make html
       - name: Deploy to gh-pages
         if: ${{ !env.ACT }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/docs/html

--- a/.github/workflows/openapijson.yml
+++ b/.github/workflows/openapijson.yml
@@ -32,7 +32,7 @@ jobs:
           version: ^5.0.0
       - name: Deploy to gh-pages
         if: ${{ !env.ACT }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: swagger-ui


### PR DESCRIPTION
Updated GitHub Actions workflows to use Node.js 20 this should fix the deprecated warnings #94 