### PR TITLE
feat: add DocsV2 to compose

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -541,6 +541,63 @@ services:
       - kraftwerk_shared_fake:/pvarki
       - kwinit_data:/data/persistent
 
+  docs:
+    image: pvarki/pvarkidocs:latest
+    environment:
+      DOCS_DOMAIN: *docsdomain
+      DOCS_PORT: "4439" # Help docusaurus build correct static links under local mode
+    networks:
+      - intranet
+      - apinet
+      - productnet
+    volumes:
+      - docs_data:/data/persistent
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3001/health || (echo 'Healthcheck failed' && exit 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  docsnginx:
+    <<: *nginxbuildinfo
+    volumes:
+      - nginx_templates:/nginx_templates
+      - ca_public:/ca_public
+      - le_certs:/le_certs
+    environment:
+      NGINX_HOST: *productdomain
+      NGINX_HTTPS_PORT: 4777
+      NGINX_UPSTREAM: "docs"
+      NGINX_UPSTREAM_PORT: "3001"
+      NGINX_CERT_NAME: "rasenmaeher"
+      NGINX_TEMPLATE_DIR: "templates_productapi"
+      CFSSL_OCSP_BIND_PORT: *oscpport
+      NGINX_OCSP_UPSTREAM: *ocsphost
+      DNS_RESOLVER_IP: *dnsresolver
+    networks:
+      - productnet
+      - intranet
+      - ocspnet
+    ports:
+      - 4777:4777
+    depends_on:
+      miniwerk:
+        condition: service_completed_successfully
+      nginx_templates:
+        condition: service_completed_successfully
+      docs:
+        condition: service_healthy
+    healthcheck:
+      test: 'curl -s localhost:3001/healthcheck || exit 1'
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+
 ######################
 # Begin: Fakeproduct #
 ######################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-domains_env:
   PRODUCT_DOMAIN: &productdomain "fake.${SERVER_DOMAIN:?domain must be defined}"
   TAK_DOMAIN: &takdomain "tak.${SERVER_DOMAIN:?domain must be defined}"
   KC_DOMAIN:  &kcdomain "kc.${SERVER_DOMAIN:?domain must be defined}"
+  DOCS_DOMAIN:  &docsdomain "kc.${SERVER_DOMAIN:?domain must be defined}"
   TAK_RMAPI_PORT: &takapiport ${TAK_RMAPI_PORT:-4626}
   DNS_RESOLVER_IP: &dnsresolver ${DNS_RESOLVER_IP:-127.0.0.11}  # Must be able to resolve docker internal names
   OCSCP_RESPONDER:  &publicocsp "https://${SERVER_DOMAIN:?domain must be defined}:${NGINX_HTTPS_PORT:-443}/ca/ocsp"  # The public URL
@@ -141,7 +142,7 @@ services:
       MW_LE_TEST: ${MW_LE_TEST:-true}  # see example_env.sh
       MW_MKCERT: ${MW_MKCERT:-false}  # When LetEncrypt cannot be used set to "true"
       MW_KEYTYPE: "rsa"
-      MW_PRODUCTS: "tak,kc,bl"
+      MW_PRODUCTS: "tak,kc,bl,docs"
     volumes:
       - kraftwerk_shared_fake:/pvarkishares/fake
       - kraftwerk_shared_tak:/pvarkishares/tak
@@ -511,6 +512,63 @@ services:
       - kraftwerk_shared_fake:/pvarki
       - kwinit_data:/data/persistent
 
+  docs:
+    image: pvarki/pvarkidocs:latest
+    environment:
+      DOCS_DOMAIN: *docsdomain
+    networks:
+      - intranet
+      - apinet
+      - productnet
+    volumes:
+      - docs_data:/data/persistent
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3001/health || (echo 'Healthcheck failed' && exit 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  docsnginx:
+    <<: *nginxbuildinfo
+    volumes:
+      - nginx_templates:/nginx_templates
+      - ca_public:/ca_public
+      - le_certs:/le_certs
+    environment:
+      NGINX_HOST: *productdomain
+      NGINX_HTTPS_PORT: 4777
+      NGINX_UPSTREAM: "docs"
+      NGINX_UPSTREAM_PORT: "3001"
+      NGINX_CERT_NAME: "rasenmaeher"
+      NGINX_TEMPLATE_DIR: "templates_productapi"
+      CFSSL_OCSP_BIND_PORT: *oscpport
+      NGINX_OCSP_UPSTREAM: *ocsphost
+      DNS_RESOLVER_IP: *dnsresolver
+    networks:
+      - productnet
+      - intranet
+      - ocspnet
+    ports:
+      - 4777:4777
+    depends_on:
+      miniwerk:
+        condition: service_completed_successfully
+      nginx_templates:
+        condition: service_completed_successfully
+      docs:
+        condition: service_healthy
+    healthcheck:
+      test: 'curl -s localhost:3001/healthcheck || exit 1'
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
 
 ######################
 # Begin: Battlelog #
@@ -856,3 +914,4 @@ volumes:
   nginx_templates:
   kraftwerk_shared_bl:
   blapi_data:
+  docs_data:


### PR DESCRIPTION
# What Does This PR Do
- Add the DocsV2 container (pvarkidocs)

# Why
1. Make it easy to make these docs for users, by non-developer subject matter experts. The DocsV2 container does this well, utilizing Docusaurus for static site building and possibly an external WYSIWYG wiki-like editor to collaborate on them.
2. Make it easy to hold & develop developer docs, which are made into this same DocsV2 container. DocsV2 auto-pulls markdown documentation from integration repo & submodules, as well as we can write that.

# How
- Refer the container as latest, so we ship the cutting edge in docs which potentially develop very fast. (Discussion point 1)
- Use productapi-y "docsnginx" as a reverse proxy for it (Discussion point 2).
- Request mTLS cert from users (Discussion point 3).

# Discussion points
## 1, latest or else
### Latest:
+ always have up-to-date docs. 
- same release number has different versions on it
- we got to secure the DocsV2 container shipping especially well then if we just trust any latest version of it, might be a security-implied question even though this is just a static site?
### Tagged version
+ one Deploy App release, same things inside, always
- potentially janky updating if and when docs do fly while other things potentially don't update like, weekly

## 2, docsnginx or not
Original many nginx'es setup was for distributed microarchitecture so should or should we not use a separate reverse proxy for docs or not?
At least for me it looked like the most simple option to config on compose.yml so I used that.

## 3, requiring mTLS certs to read
Not now but at some point, we have a distribution question here. Do we want to show a specific version of docs to enrolled users (and hide this behind mTLS auth), or show the docs for everybody?

For the sense of security I'd lock up in-app docs even now behind the mTLS auth. Even if it does not count for limited distribution; these docs are (now) FOSS. I guess what this does is to possibly hide like, of which version that specific instance is. 

Maybe in the future we have limited-release versions of docs that are baked elsewhere & stored elsewhere & so it's relevant from that viewpoint as well, to request authentication.

# Credits
@Lonimokio 's nice work with DocsV2 container
