### PR TITLE
[1.11.1] Fix: Switch to bitnamilegacy:keycloak due to Bitnami changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.0
+current_version = 1.11.1
 commit = False
 tag = False
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,7 +313,7 @@ services:
         condition: service_completed_successfully
 
   keycloak:
-    image: bitnami/keycloak:${KEYCLOAK_VERSION:-24.0.5}
+    image: bitnamilegacy/keycloak:${KEYCLOAK_VERSION:-24.0.5}
     user: root
     environment:
       <<: [*kcdbconfig_env, *keycloak_users_env, *keycloak_tls_env]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ x-keycloakinit_users_env: &keycloakinit_users_env
   KEYCLOAK_PASSWORD: *kcadminpass # pragma: allowlist secret
 
 x-takbuilds: &takbuildinfo
-  image: &takimage "pvarki/takserver:${TAK_RELEASE:-5.4-RELEASE-19}-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}"
+  image: &takimage "pvarki/takserver:${TAK_RELEASE:-5.4-RELEASE-19}-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}"
   build:
     context: ./takserver
     dockerfile: Dockerfile
@@ -83,7 +83,7 @@ x-takbuilds: &takbuildinfo
       TAK_RELEASE: ${TAK_RELEASE:-5.4-RELEASE-19}
 
 x-nginxbuilds: &nginxbuildinfo
-  image: pvarki/nginx:1.27-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+  image: pvarki/nginx:1.27-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
   build:
     context: ./nginx
     dockerfile: Dockerfile
@@ -122,7 +122,7 @@ x-takserver_env: &takserver_env
 
 services:
   miniwerk:
-    image: pvarki/miniwerk:1.3.5-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/miniwerk:1.3.5-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./miniwerk
       dockerfile: Dockerfile
@@ -151,7 +151,7 @@ services:
       - "80:80"
 
   cfssl:
-    image: pvarki/cfssl:api-1.2.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/cfssl:api-1.2.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./cfssl
       dockerfile: Dockerfile
@@ -174,7 +174,7 @@ services:
     restart: unless-stopped
 
   ocsp:
-    image: pvarki/cfssl:ocsp-1.2.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/cfssl:ocsp-1.2.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./cfssl
       dockerfile: Dockerfile
@@ -200,7 +200,7 @@ services:
     restart: unless-stopped
 
   ocsprest:
-    image: pvarki/cfssl:ocsprest-1.0.4-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/cfssl:ocsprest-1.0.4-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./cfssl
       dockerfile: Dockerfile
@@ -260,7 +260,7 @@ services:
         condition: service_completed_successfully
 
   openldap:
-    image: pvarki/openldap:1.0.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/openldap:1.0.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./keycloak/openldap
       dockerfile: Dockerfile
@@ -370,7 +370,7 @@ services:
         condition: service_healthy
 
   rmapi:
-    image: pvarki/rmapi:1.7.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/rmapi:1.7.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./api
       dockerfile: Dockerfile
@@ -392,7 +392,7 @@ services:
       RM_KC_PASSWORD: *kcadminpass  # pragma: allowlist secret
       RM_KC_REALM: *kc_realm
       RM_LOG_LEVEL: "INFO"
-      RELEASE_TAG: ${RELEASE_TAG:-1.11.0}
+      RELEASE_TAG: ${RELEASE_TAG:-1.11.1}
     networks:
       - apinet
       - kcnet
@@ -426,19 +426,19 @@ services:
     restart: unless-stopped
 
   rmui:
-    image: pvarki/rmui:1.3.1-${VITE_ASSET_SET:-neutral}-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/rmui:1.3.1-${VITE_ASSET_SET:-neutral}-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./ui
       dockerfile: Dockerfile
       target: production
       args:
         VITE_ASSET_SET: ${VITE_ASSET_SET:-neutral}
-        RELEASE_TAG: ${RELEASE_TAG:-1.11.0}
+        RELEASE_TAG: ${RELEASE_TAG:-1.11.1}
     volumes:
       - rmui_files:/deliver
 
   nginx_templates:
-    image: pvarki/nginx:templates-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/nginx:templates-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./nginx
       dockerfile: Dockerfile
@@ -498,7 +498,7 @@ services:
     restart: unless-stopped
 
   kwinit:  # Mostly to make sure it's built
-    image: pvarki/kw_product_init:1.0.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/kw_product_init:1.0.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./kw_product_init
       dockerfile: Dockerfile
@@ -515,7 +515,7 @@ services:
 # Begin: Battlelog #
 ######################
   blapi:
-    image: pvarki/blapi:1.0.0-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/blapi:1.0.0-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./battlelog
       dockerfile: Dockerfile
@@ -701,7 +701,7 @@ services:
     restart: unless-stopped
 
   takrmapi:
-    image: pvarki/takrmapi:1.5.2-tak${TAK_RELEASE:-5.4-RELEASE-19}-d${RELEASE_TAG:-1.11.0}${DOCKER_TAG_EXTRA:-}
+    image: pvarki/takrmapi:1.5.2-tak${TAK_RELEASE:-5.4-RELEASE-19}-d${RELEASE_TAG:-1.11.1}${DOCKER_TAG_EXTRA:-}
     build:
       context: ./takintegration
       dockerfile: Dockerfile

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: "1.11.0"  # use bump2version to bump this
+version: "1.11.1"  # use bump2version to bump this


### PR DESCRIPTION
# What Does This PR Do
- Changes our keycloak dependency to bitnamilegacy, due to their [recent changes](https://hub.docker.com/r/bitnami/keycloak)
- TODO: Move soon to fresh keycloak images

# What to note
1.11.1, as this is based on 1.11.0. 