### PR TITLE
feat: wire blapi to the prod TAK server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -608,10 +608,29 @@ services:
       target: production
     environment:
       <<: [*bldbconfig_env]
+      # TAK integration: connect to the prod TAK server using the RM-issued
+      # mtlsclient cert that kw_product_init writes to /data/persistent on
+      # first run. See battlelog/docs/prod-tak.md for details.
+      TAK_ENABLED: "true"
+      TAK_HOST: takconfig
+      TAK_TLS_SERVERNAME: *takdomain
+      TAK_STREAM_PORT: "8089"
+      TAK_STREAM_TLS: "true"
+      TAK_REJECT_UNAUTHORIZED: "true"
+      TAK_CLIENT_CERT_PATH: /data/persistent/public/mtlsclient.pem
+      TAK_CLIENT_KEY_PATH: /data/persistent/private/mtlsclient.key
+      TAK_CA_PATH: /ca_public/ca_chain.pem
+      TAK_DB_POLL_ENABLED: "true"
+      TAK_DB_HOST: postgres
+      TAK_DB_PORT: "5432"
+      TAK_DB_NAME: *takdbname
+      TAK_DB_USER: *takdbuser
+      TAK_DB_PASSWORD: *takdbpass
     networks:
       - productnet
       - intranet
       - dbnet
+      - taknet
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -624,6 +643,8 @@ services:
       rmapi:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      takmsg:
         condition: service_healthy
     healthcheck:
       test: 'curl http://localhost:3000/api/v1/healthcheck || exit 1'


### PR DESCRIPTION
Bumps the battlelog submodule to pvarki/typescript-liveloki-app@cf41344 which adds TAK marker/chat streaming, a TAK DB poller, and operator docs (see battlelog/docs/prod-tak.md).

Adds the compose wiring blapi needs to actually use the integration in production:

- joins blapi to the taknet network so it can reach takconfig:8089
- depends on takmsg health, so the TAK CoT stream is up before blapi tries to connect
- sets TAK_* env vars pointing the BattleLog backend at takconfig:8089 over TLS, reusing the RM-issued mtlsclient cert that kw_product_init already writes to /data/persistent on first run (no new cert minting needed)
- enables the TAK Postgres poll against the shared postgres service (tak DB, user/password from the existing *takdbname / *takdbuser / *takdbpass anchors)

No new volumes, services, or secrets are introduced. If TAK ever rejects BattleLog's mtlsclient CN due to the deployment's user-enrollment policy, follow-up work in takintegration is documented in battlelog/docs/prod-tak.md.

## User-facing summary
Example new feature:
- Added new authentication flow
Example fix to a feature:
- Fixed memory leak in cache

## Why It's Good for the Product (Release Goal)
- Improves security posture
- Reduces infrastructure costs

## Any Other You'd Like to Mention
- Open word
